### PR TITLE
gPTP: Add additional metadata to OS_IPC::update()

### DIFF
--- a/daemons/gptp/common/avbts_clock.hpp
+++ b/daemons/gptp/common/avbts_clock.hpp
@@ -61,29 +61,6 @@
    adjustment is performed */
 #define PHASE_ERROR_MAX_COUNT (6)
 
-
-/**
- * @brief Provides the clock quality abstraction.
- * Represents the quality of the clock
- * Defined at IEEE 802.1AS-2011
- * Clause 6.3.3.8
- */
-struct ClockQuality {
-	unsigned char cq_class;				/*!< Clock Class - Clause 8.6.2.2
-										  Denotes the tracebility of the synchronized time
-										  distributed by a clock master when it is grandmaster. */
-	unsigned char clockAccuracy; 		/*!< Clock Accuracy - clause 8.6.2.3.
-										  Indicates the expected time accuracy of
-										  a clock master.*/
-	int16_t offsetScaledLogVariance;	/*!< ::Offset Scaled log variance - Clause 8.6.2.4.
-										  Is the scaled, offset representation
-										  of an estimate of the PTP variance. The
-										  PTP variance characterizes the
-										  precision and frequency stability of the clock
-										  master. The PTP variance is the square of
-										  PTPDEV (See B.1.3.2). */
-};
-
 /**
  * @brief Provides the 1588 clock interface
  */

--- a/daemons/gptp/common/avbts_osipc.hpp
+++ b/daemons/gptp/common/avbts_osipc.hpp
@@ -37,6 +37,7 @@
 #include <stdint.h>
 #include <ptptypes.hpp>
 #include <avbts_port.hpp>
+#include <ieee1588.hpp>
 
 /**@file*/
 
@@ -72,13 +73,18 @@ public:
 	 * @param pdelay_count Count of pdelays
 	 * @param port_state Port's state
      * @param asCapable asCapable flag
+	 * @param grandmaster_id Grandmaster's id
+	 * @param grandmaster_clock_quality Grandmaster's clock quality
+	 * @param local_clock_quality Local clock quality
 	 * @return Implementation dependent.
 	 */
     virtual bool update
 	( int64_t  ml_phoffset, int64_t ls_phoffset,
 	  FrequencyRatio  ml_freqoffset, FrequencyRatio ls_freq_offset,
 	  uint64_t local_time, uint32_t sync_count, uint32_t pdelay_count,
-	  PortState port_state, bool asCapable ) = 0;
+	  PortState port_state, bool asCapable, uint8_t* grandmaster_id,
+	  ClockQuality grandmaster_clock_quality,
+	  ClockQuality local_clock_quality) = 0;
 
 	/*
 	 * Destroys IPC

--- a/daemons/gptp/common/ieee1588.hpp
+++ b/daemons/gptp/common/ieee1588.hpp
@@ -127,6 +127,28 @@ class InterfaceLabel {
 };
 
 /**
+ * Provides the clock quality abstraction.
+ * Represents the quality of the clock
+ * Defined at IEEE 802.1AS-2011
+ * Clause 6.3.3.8
+ */
+struct ClockQuality {
+	unsigned char cq_class;				/*!< Clock Class - Clause 8.6.2.2
+										  Denotes the tracebility of the synchronized time
+										  distributed by a clock master when it is grandmaster. */
+	unsigned char clockAccuracy;		/*!< Clock Accuracy - clause 8.6.2.3.
+										  Indicates the expected time accuracy of
+										  a clock master.*/
+	int16_t offsetScaledLogVariance;	/*!< ::Offset Scaled log variance - Clause 8.6.2.4.
+										  Is the scaled, offset representation
+										  of an estimate of the PTP variance. The
+										  PTP variance characterizes the
+										  precision and frequency stability of the clock
+										  master. The PTP variance is the square of
+										  PTPDEV (See B.1.3.2). */
+};
+
+/**
  * @brief Provides a ClockIdentity abstraction
  * See IEEE 802.1AS-2011 Clause 8.5.2.2
  */

--- a/daemons/gptp/common/ieee1588clock.cpp
+++ b/daemons/gptp/common/ieee1588clock.cpp
@@ -345,14 +345,19 @@ void IEEE1588Clock::setMasterOffset
 	_local_system_freq_offset = local_system_freq_offset;
 
 	if (port->getTestMode()) {
-		GPTP_LOG_STATUS("Clock offset:%lld   Clock rate ratio:%Lf   Sync Count:%u   PDelay Count:%u", 
+		GPTP_LOG_STATUS("Clock offset:%lld   Clock rate ratio:%Lf   Sync Count:%u   PDelay Count:%u",
 						master_local_offset, master_local_freq_offset, sync_count, pdelay_count);
 	}
 
-	if( ipc != NULL ) ipc->update
+	if( ipc != NULL ) {
+		uint8_t grandmaster_id[PTP_CLOCK_IDENTITY_LENGTH];
+		grandmaster_clock_identity.getIdentityString( grandmaster_id );
+		ipc->update
 		( master_local_offset, local_system_offset, master_local_freq_offset,
 		  local_system_freq_offset, TIMESTAMP_TO_NS(local_time), sync_count,
-		  pdelay_count, port_state, asCapable );
+		  pdelay_count, port_state, asCapable, grandmaster_id,
+		  getGrandmasterClockQuality(), getClockQuality() );
+	}
 
 	if( master_local_offset == 0 && master_local_freq_offset == 1.0 ) {
 		return;

--- a/daemons/gptp/common/ipcdef.hpp
+++ b/daemons/gptp/common/ipcdef.hpp
@@ -61,6 +61,7 @@
 #endif /*__unix__ / _WIN*/
 
 #include <ptptypes.hpp>
+#include <ieee1588.hpp>
 
 /**
  * @brief Provides a data structure for gPTP time
@@ -76,6 +77,9 @@ typedef struct {
     bool asCapable;                 //!< asCapable flag: true = device is AS Capable; false otherwise
     PortState port_state;			//!< gPTP port state. It can assume values defined at ::PortState
     PID_TYPE process_id;			//!< Process id number
+    uint8_t grandmaster_id[PTP_CLOCK_IDENTITY_LENGTH];	//!< Grandmaster id number
+    ClockQuality grandmaster_clock_quality;				//!< Grandmaster clock quality
+    ClockQuality local_clock_quality;					//!< Local clock quality
 } gPtpTimeData;
 
 /*

--- a/daemons/gptp/linux/src/linux_hal_common.cpp
+++ b/daemons/gptp/linux/src/linux_hal_common.cpp
@@ -780,7 +780,9 @@ bool LinuxSharedMemoryIPC::init( OS_IPC_ARG *barg ) {
 bool LinuxSharedMemoryIPC::update
 (int64_t ml_phoffset, int64_t ls_phoffset, FrequencyRatio ml_freqoffset,
  FrequencyRatio ls_freqoffset, uint64_t local_time, uint32_t sync_count,
- uint32_t pdelay_count, PortState port_state, bool asCapable ) {
+ uint32_t pdelay_count, PortState port_state, bool asCapable,
+ uint8_t* grandmaster_id, ClockQuality grandmaster_clock_quality,
+ ClockQuality local_clock_quality) {
 	int buf_offset = 0;
 	pid_t process_id = getpid();
 	char *shm_buffer = master_offset_buffer;
@@ -800,6 +802,11 @@ bool LinuxSharedMemoryIPC::update
         ptimedata->asCapable = asCapable;
 		ptimedata->port_state   = port_state;
 		ptimedata->process_id   = process_id;
+		memcpy(&(ptimedata->grandmaster_id),
+		       grandmaster_id,
+		       PTP_CLOCK_IDENTITY_LENGTH );
+		ptimedata->grandmaster_clock_quality = grandmaster_clock_quality;
+		ptimedata->local_clock_quality = local_clock_quality;
 		/* unlock */
 		pthread_mutex_unlock((pthread_mutex_t *) shm_buffer);
 	}

--- a/daemons/gptp/linux/src/linux_hal_common.hpp
+++ b/daemons/gptp/linux/src/linux_hal_common.hpp
@@ -641,12 +641,17 @@ public:
 	 * @param pdelay_count Count of pdelays
 	 * @param port_state Port's state
 	 * @param asCapable asCapable flag
+	 * @param grandmaster_id Grandmaster ID
+	 * @param grandmaster_clock_quality Grandmaster clock quality
+	 * @param local_clock_quality Local clock quality
 	 * @return TRUE
 	 */
 	virtual bool update
 	(int64_t ml_phoffset, int64_t ls_phoffset, FrequencyRatio ml_freqoffset,
 	 FrequencyRatio ls_freqoffset, uint64_t local_time, uint32_t sync_count,
-	 uint32_t pdelay_count, PortState port_state, bool asCapable );
+	 uint32_t pdelay_count, PortState port_state, bool asCapable,
+	 uint8_t* grandmaster_id, ClockQuality grandmaster_clock_quality,
+	 ClockQuality local_clock_quality );
 
 	/**
 	 * @brief unmaps and unlink shared memory

--- a/daemons/gptp/windows/daemon_cl/windows_hal.cpp
+++ b/daemons/gptp/windows/daemon_cl/windows_hal.cpp
@@ -175,9 +175,12 @@ bool WindowsNamedPipeIPC::init(OS_IPC_ARG *arg) {
 	return true;
 }
 
-bool WindowsNamedPipeIPC::update(int64_t ml_phoffset, int64_t ls_phoffset, FrequencyRatio ml_freqoffset, FrequencyRatio ls_freq_offset, uint64_t local_time,
-	uint32_t sync_count, uint32_t pdelay_count, PortState port_state, bool asCapable) {
-
+bool WindowsNamedPipeIPC::update
+	(int64_t ml_phoffset, int64_t ls_phoffset, FrequencyRatio ml_freqoffset,
+	 FrequencyRatio ls_freq_offset, uint64_t local_time, uint32_t sync_count,
+	 uint32_t pdelay_count, PortState port_state, bool asCapable,
+	 uint8_t* grandmaster_id, ClockQuality grandmaster_clock_quality,
+	 ClockQuality local_clock_quality ) {
 
 	lOffset_.get();
 	lOffset_.local_time = local_time;

--- a/daemons/gptp/windows/daemon_cl/windows_hal.hpp
+++ b/daemons/gptp/windows/daemon_cl/windows_hal.hpp
@@ -819,10 +819,17 @@ public:
 	 * @param  pdelay_count Counts of pdelays
 	 * @param  port_state PortState information
      * @param  asCapable asCapable flag
+	 * @param  grandmaster_id Grandmaster ID
+	 * @param  grandmaster_clock_quality Grandmaster clock quality
+	 * @param  local_clock_quality Local clock quality
 	 * @return TRUE if sucess; FALSE if error
 	 */
-	virtual bool update(int64_t ml_phoffset, int64_t ls_phoffset, FrequencyRatio ml_freqoffset, FrequencyRatio ls_freq_offset, uint64_t local_time,
-		uint32_t sync_count, uint32_t pdelay_count, PortState port_state, bool asCapable);
+	virtual bool update
+	(int64_t ml_phoffset, int64_t ls_phoffset, FrequencyRatio ml_freqoffset,
+	 FrequencyRatio ls_freq_offset, uint64_t local_time, uint32_t sync_count,
+	 uint32_t pdelay_count, PortState port_state, bool asCapable,
+	 uint8_t* grandmaster_id, ClockQuality grandmaster_clock_quality,
+	 ClockQuality local_clock_quality );
 };
 
 #endif


### PR DESCRIPTION
Add additional metadata to gPTP's IPC mechanism:
 - grandmaster_id
 - grandmaster_clock_quality
 - local_clock_quality
Move struct ClockQuality to avoid circular dependency when used in ipcdef.