### PR TITLE
gPTP: Resolve warning: "comparison between signed and unsigned..."

### DIFF
--- a/daemons/gptp/common/avbts_port.hpp
+++ b/daemons/gptp/common/avbts_port.hpp
@@ -317,7 +317,7 @@ class IEEE1588Port {
 	char log_min_mean_pdelay_req_interval;
 	bool burst_enabled;
 	static const int64_t ONE_WAY_DELAY_DEFAULT = 3600000000000;
-	static const int64_t INVALID_LINKDELAY = 3600000000000;
+	static const uint64_t INVALID_LINKDELAY = 3600000000000;
 	static const int64_t NEIGHBOR_PROP_DELAY_THRESH = 800;
 	static const unsigned int DEFAULT_SYNC_RECEIPT_THRESH = 5;
 	static const unsigned int DUPLICATE_RESP_THRESH = 3;


### PR DESCRIPTION
Resolve compiler warning: "comparison between signed and unsigned
integer expressions." INVALID_LINKDELAY in avbts_port.hpp is defined
as a const int64_t, but is only ever compared against a uint64_t value.
Since it is const and initialized with a postive value, it should be
safe to make it an unsigned int.