### PR TITLE
gPTP: prevent listening thread dying on error

### DIFF
--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -448,7 +448,6 @@ void *IEEE1588Port::openPort(IEEE1588Port *port)
 		} else if (rrecv == net_fatal) {
 			GPTP_LOG_ERROR("read from network interface failed");
 			this->processEvent(FAULT_DETECTED);
-			break;
 		}
 	}
 


### PR DESCRIPTION
Bringing the ethernet port up and down with 'ifconfig eth0 down'
and 'ifconfig eth0 up' causes gPTP to enter an unrecoverable state
in which it will not achieve asCapable. This was found to be due to the
listener thread exiting on receiving an error from the port, causing
incoming packets to go unprocessed.

Prevent the listening thread from exiting by removing the break statement
when an error is encountered. Errors will still be logged.