### PR TITLE
Add a setPriority2() method to IEEE1588Clock class.

### DIFF
--- a/daemons/gptp/common/avbts_clock.hpp
+++ b/daemons/gptp/common/avbts_clock.hpp
@@ -400,6 +400,15 @@ public:
   }
 
   /**
+   * @brief  Sets IEEE1588Clock priority2 attribute (IEEE 802.1AS clause 8.6.2.5)
+   * @return void
+   */
+  void setPriority2( unsigned char newPriority2 ) {
+      /*TODO: add range check */
+      priority2 = newPriority2;
+  }
+
+  /**
    * @brief  Gets nextPortId value
    * @return The remaining value from the division of current number of ports by
    * (maximum number of ports + 1) + 1


### PR DESCRIPTION
Add a setPriority2() method to IEEE1588Clock class to allow the priority2
value to be set. This method does no range checking!