### PR TITLE
Fixing a segfault that occurs when sending a PDelayReq.

### DIFF
--- a/daemons/gptp/common/avbts_port.hpp
+++ b/daemons/gptp/common/avbts_port.hpp
@@ -404,7 +404,7 @@ class IEEE1588Port {
 
 	OSCondition *port_ready_condition;
 
-	OSLock *pdelay_rx_lock;
+	OSLock *last_pdelay_lock;
 	OSLock *port_tx_lock;
 
 	OSLock *syncReceiptTimerLock;
@@ -955,27 +955,27 @@ class IEEE1588Port {
 	}
 
 	/**
-	 * @brief  Locks PDelay RX
+	 * @brief  Locks the last_pdelay variables
 	 * @return TRUE if acquired the lock. FALSE otherwise
 	 */
-	bool getPDelayRxLock() {
-		return pdelay_rx_lock->lock() == oslock_ok ? true : false;
+	bool getLastPDelayLock() {
+		return last_pdelay_lock->lock() == oslock_ok ? true : false;
 	}
 
 	/**
-	 * @brief  Do a trylock on the PDelay RX
+	 * @brief  Do a trylock for the last_pdelay variables
 	 * @return TRUE if acquired the lock. FALSE otherwise.
 	 */
-	bool tryPDelayRxLock() {
-		return pdelay_rx_lock->trylock() == oslock_ok ? true : false;
+	bool tryLastPDelayLock() {
+		return last_pdelay_lock->trylock() == oslock_ok ? true : false;
 	}
 
 	/**
-	 * @brief  Unlocks PDelay RX.
+	 * @brief  Unlocks the last_pdelay variables
 	 * @return TRUE if success. FALSE otherwise
 	 */
-	bool putPDelayRxLock() {
-		return pdelay_rx_lock->unlock() == oslock_ok ? true : false;
+	bool putLastPDelayLock() {
+		return last_pdelay_lock->unlock() == oslock_ok ? true : false;
 	}
 
 	/**

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1282,8 +1282,8 @@ void PTPMessagePathDelayResp::processMessage(IEEE1588Port * port)
 
 	port->incCounter_ieee8021AsPortStatRxPdelayResponse();
 
-	if (port->tryPDelayRxLock() != true) {
-		GPTP_LOG_ERROR("Failed to get PDelay RX Lock");
+	if (port->getLastPDelayLock() != true) {
+		GPTP_LOG_ERROR("Failed to get last PDelay lock while processing a PDelayResp");
 		return;
 	}
 
@@ -1340,7 +1340,7 @@ bypass_verify_duplicate:
 		delete old_pdelay_resp;
 	}
 
-	port->putPDelayRxLock();
+	port->putLastPDelayLock();
 	_gc = false;
 
 	return;
@@ -1442,8 +1442,10 @@ void PTPMessagePathDelayRespFollowUp::processMessage(IEEE1588Port * port)
 
 	port->incCounter_ieee8021AsPortStatRxPdelayResponseFollowUp();
 
-	if (port->tryPDelayRxLock() != true)
+	if (port->getLastPDelayLock() != true) {
+		GPTP_LOG_ERROR("Failed to get last PDelay lock while processing a PDelay Follow Up");
 		return;
+	}
 
 	PTPMessagePathDelayReq *req = port->getLastPDelayReq();
 	PTPMessagePathDelayResp *resp = port->getLastPDelayResp();
@@ -1662,7 +1664,7 @@ void PTPMessagePathDelayRespFollowUp::processMessage(IEEE1588Port * port)
 	_gc = true;
 
  defer:
-	port->putPDelayRxLock();
+	port->putLastPDelayLock();
 
 	return;
 }


### PR DESCRIPTION
Fixing a segfault that occurs when sending a PDelayReq while simultaneously
processing an unexpected PDelayRespFollowup. This can happen when running
multiple instances of gPTP over a non-802.1as-capable network switch that
forwards all layer two packets to every port. The thread that processes
incoming PDelayRespFollowup messages was deleting the port's pointer to the
last PDelayReq, which it was still in the process of sending. Repurposing an
existing lock to protect the last_pdelay_* pointers.