### PR TITLE
Reducing log noise when not asCapable

### DIFF
--- a/daemons/gptp/common/avbts_port.hpp
+++ b/daemons/gptp/common/avbts_port.hpp
@@ -340,6 +340,7 @@ class IEEE1588Port {
 	bool _syntonize;
 
 	bool asCapable;
+	bool asCapableEvaluated;
 
 	/* Automotive Profile : Static variables */
 	// port_state : already defined as port_state
@@ -573,6 +574,7 @@ class IEEE1588Port {
 	 * @return void
 	 */
 	void restartPDelay() {
+		reinitializeAsCapable();
 		_peer_offset_init = false;
 	}
 
@@ -590,6 +592,19 @@ class IEEE1588Port {
 			_peer_offset_init = false;
 		}
 		asCapable = ascap;
+
+		// Assumes that a call to setAsCapable() means that 802.1AS capability
+		// has been evaluated.
+		asCapableEvaluated = true;
+	}
+
+	/**
+	 * @brief  Reinitializes the asCapable variables
+	 * @return void
+	 */
+	void reinitializeAsCapable() {
+		asCapable = false;
+		asCapableEvaluated = false;
 	}
 
 	/**
@@ -597,6 +612,12 @@ class IEEE1588Port {
 	 * @return asCapable flag.
 	 */
 	bool getAsCapable() { return( asCapable ); }
+
+	/**
+	 * @brief  Checks if 802.1AS capability has been evaluated at least once
+	 * @return asCapable set at least once.
+	 */
+	bool getAsCapableEvaluated() { return( asCapableEvaluated ); }
 
 	/**
 	 * @brief  Gets the AVnu automotive profile flag

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -256,6 +256,7 @@ void IEEE1588Port::startPDelay() {
 		}
 		else {
 			pdelay_started = true;
+			reinitializeAsCapable();
 			startPDelayIntervalTimer(32000000);
 		}
 	}
@@ -1158,7 +1159,10 @@ void IEEE1588Port::processEvent(Event e)
 		break;
 	case PDELAY_RESP_RECEIPT_TIMEOUT_EXPIRES:
 		if (!automotive_profile) {
-			GPTP_LOG_EXCEPTION("PDelay Response Receipt Timeout");
+			GPTP_LOG_DEBUG("PDelay Response Receipt Timeout");
+			if ( getAsCapable() || !getAsCapableEvaluated() ) {
+				GPTP_LOG_STATUS("Did not receive a valid PDelay Response before the timeout. Not AsCapable");
+         }
 			setAsCapable(false);
 		}
 		pdelay_count = 0;


### PR DESCRIPTION
Reducing log level from error to debug for a few messages that are not actually
faulty to the protocol. They just result in the port not being asCapable. Also,
changing the behavior of a few log statements so that they only get printed
when the asCapable state changes. This avoids a lot of noise when gPTP is not
connected to an asCapable peer which helps users to identify what initially
caused gPTP to change states.