### PR TITLE
Fix deadlock when link up event is generated

### DIFF
--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -521,7 +521,8 @@ void IEEE1588Port::processEvent(Event e)
 			unsigned long long interval4;
 			Event e3 = NULL_EVENT;
 			Event e4 = NULL_EVENT;
-
+			
+			// TODO:Start PDelay only if the link is up.
 			if (!automotive_profile) {
 				if (port_state != PTP_SLAVE && port_state != PTP_MASTER) {
 					GPTP_LOG_STATUS("Starting PDelay");

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -712,7 +712,7 @@ void IEEE1588Port::processEvent(Event e)
 		break;
 
 	case LINKUP:
-		haltPdelay(false);
+		stopPDelay();
 		startPDelay();
 		if (automotive_profile) {
 			GPTP_LOG_EXCEPTION("LINKUP");


### PR DESCRIPTION
This pull request fixes a deadlock which can happen when peer delay is in progress and NIC link up event is generated. 