### PR TITLE
gPTP: Set haltPdelay to false in LINKUP

### DIFF
--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -714,6 +714,7 @@ void IEEE1588Port::processEvent(Event e)
 
 	case LINKUP:
 		stopPDelay();
+		haltPdelay(false);
 		startPDelay();
 		if (automotive_profile) {
 			GPTP_LOG_EXCEPTION("LINKUP");


### PR DESCRIPTION
This is a follow up fix for https://github.com/ni/Open-AVB/pull/16. Setting haltPdelay to false so the pDelay can start.