### PR TITLE
gPTP: Set haltPdelay to false in LINKUP

### DIFF
--- a/daemons/gptp/common/ether_port.cpp
+++ b/daemons/gptp/common/ether_port.cpp
@@ -393,6 +393,7 @@ bool EtherPort::_processEvent( Event e )
 
 		break;
 	case LINKUP:
+		stopPDelay();
 		haltPdelay(false);
 		startPDelay();
 		if (automotive_profile) {


### PR DESCRIPTION
This is a follow up fix for https://github.com/ni/Open-AVB/pull/16. Setting haltPdelay to false so the pDelays could start.
Conflicts:
	daemons/gptp/common/ieee1588port.cpp