### PR TITLE
Fixing a segfault that occurs when sending a PDelayReq.

### DIFF
--- a/daemons/gptp/common/ether_port.cpp
+++ b/daemons/gptp/common/ether_port.cpp
@@ -156,7 +156,7 @@ EtherPort::EtherPort( PortInit_t *portInit ) :
 
 bool EtherPort::_init_port( void )
 {
-	pdelay_rx_lock = lock_factory->createLock(oslock_recursive);
+	last_pdelay_lock = lock_factory->createLock(oslock_recursive);
 	port_tx_lock = lock_factory->createLock(oslock_recursive);
 
 	pDelayIntervalTimerLock = lock_factory->createLock(oslock_recursive);
@@ -505,6 +505,11 @@ bool EtherPort::_processEvent( Event e )
 		{
 			Timestamp req_timestamp;
 
+			if (getLastPDelayLock() != true) {
+				GPTP_LOG_ERROR("Failed to get last PDelay lock before sending a PDelayReq");
+				break;
+			}
+
 			PTPMessagePathDelayReq *pdelay_req =
 			    new PTPMessagePathDelayReq(this);
 			PortIdentity dest_id;
@@ -550,6 +555,8 @@ bool EtherPort::_processEvent( Event e )
 					interval : EVENT_TIMER_GRANULARITY;
 				startPDelayIntervalTimer(interval);
 			}
+
+			putLastPDelayLock();
 		}
 		break;
 	case SYNC_INTERVAL_TIMEOUT_EXPIRES:
@@ -623,7 +630,10 @@ bool EtherPort::_processEvent( Event e )
 		break;
 	case PDELAY_DEFERRED_PROCESSING:
 		GPTP_LOG_DEBUG("PDELAY_DEFERRED_PROCESSING occured");
-		pdelay_rx_lock->lock();
+		if (getLastPDelayLock() != true) {
+			GPTP_LOG_ERROR("Failed to get last PDelay lock before processing a deferred PDelay Follow Up");
+			break;
+		}
 		if (last_pdelay_resp_fwup == NULL) {
 			GPTP_LOG_ERROR("PDelay Response Followup is NULL!");
 			abort();
@@ -633,7 +643,7 @@ bool EtherPort::_processEvent( Event e )
 			delete last_pdelay_resp_fwup;
 			this->setLastPDelayRespFollowUp(NULL);
 		}
-		pdelay_rx_lock->unlock();
+		putLastPDelayLock();
 		break;
 	case PDELAY_RESP_RECEIPT_TIMEOUT_EXPIRES:
 		if (!automotive_profile) {

--- a/daemons/gptp/common/ether_port.hpp
+++ b/daemons/gptp/common/ether_port.hpp
@@ -137,7 +137,7 @@ class EtherPort : public CommonPort
 
 	OSCondition *port_ready_condition;
 
-	OSLock *pdelay_rx_lock;
+	OSLock *last_pdelay_lock;
 	OSLock *port_tx_lock;
 
 	OSLock *pDelayIntervalTimerLock;
@@ -375,27 +375,27 @@ protected:
 	}
 
 	/**
-	 * @brief  Locks PDelay RX
+	 * @brief  Locks the last_pdelay variables
 	 * @return TRUE if acquired the lock. FALSE otherwise
 	 */
-	bool getPDelayRxLock() {
-		return pdelay_rx_lock->lock() == oslock_ok ? true : false;
+	bool getLastPDelayLock() {
+		return last_pdelay_lock->lock() == oslock_ok ? true : false;
 	}
 
 	/**
-	 * @brief  Do a trylock on the PDelay RX
+	 * @brief  Do a trylock for the last_pdelay variables
 	 * @return TRUE if acquired the lock. FALSE otherwise.
 	 */
-	bool tryPDelayRxLock() {
-		return pdelay_rx_lock->trylock() == oslock_ok ? true : false;
+	bool tryLastPDelayLock() {
+		return last_pdelay_lock->trylock() == oslock_ok ? true : false;
 	}
 
 	/**
-	 * @brief  Unlocks PDelay RX.
+	 * @brief  Unlocks the last_pdelay variables
 	 * @return TRUE if success. FALSE otherwise
 	 */
-	bool putPDelayRxLock() {
-		return pdelay_rx_lock->unlock() == oslock_ok ? true : false;
+	bool putLastPDelayLock() {
+		return last_pdelay_lock->unlock() == oslock_ok ? true : false;
 	}
 
 	bool getTxLock() {

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1320,8 +1320,8 @@ void PTPMessagePathDelayResp::processMessage( EtherPort *port )
 
 	port->incCounter_ieee8021AsPortStatRxPdelayResponse();
 
-	if (port->tryPDelayRxLock() != true) {
-		GPTP_LOG_ERROR("Failed to get PDelay RX Lock");
+	if (port->getLastPDelayLock() != true) {
+		GPTP_LOG_ERROR("Failed to get last PDelay lock while processing a PDelayResp");
 		return;
 	}
 
@@ -1378,7 +1378,7 @@ bypass_verify_duplicate:
 		delete old_pdelay_resp;
 	}
 
-	port->putPDelayRxLock();
+	port->putLastPDelayLock();
 	_gc = false;
 
 	return;
@@ -1486,8 +1486,10 @@ void PTPMessagePathDelayRespFollowUp::processMessage
 
 	port->incCounter_ieee8021AsPortStatRxPdelayResponseFollowUp();
 
-	if (port->tryPDelayRxLock() != true)
+	if (port->getLastPDelayLock() != true) {
+		GPTP_LOG_ERROR("Failed to get last PDelay lock while processing a PDelay Follow Up");
 		return;
+	}
 
 	PTPMessagePathDelayReq *req = port->getLastPDelayReq();
 	PTPMessagePathDelayResp *resp = port->getLastPDelayResp();
@@ -1706,7 +1708,7 @@ void PTPMessagePathDelayRespFollowUp::processMessage
 	_gc = true;
 
  defer:
-	port->putPDelayRxLock();
+	port->putLastPDelayLock();
 
 	return;
 }


### PR DESCRIPTION
Fixing a segfault that occurs when sending a PDelayReq while simultaneously
processing an unexpected PDelayRespFollowup. This can happen when running
multiple instances of gPTP over a non-802.1as-capable network switch that
forwards all layer two packets to every port. The thread that processes
incoming PDelayRespFollowup messages was deleting the port's pointer to the
last PDelayReq, which it was still in the process of sending. Repurposing an
existing lock to protect the last_pdelay_* pointers.

Conflicts:
	daemons/gptp/common/avbts_port.hpp
	daemons/gptp/common/ieee1588port.cpp