### PR TITLE
[gPTP] Fix bug in getTransmitAnnounce()

### DIFF
--- a/daemons/gptp/common/avbts_clock.hpp
+++ b/daemons/gptp/common/avbts_clock.hpp
@@ -434,8 +434,7 @@ public:
   * @return transmit_announce attribute
   */
   bool getTransmitAnnounce(void) {
-	  return automotive_profile_config.automotiveProfile
-	         && automotive_profile_config.transmitAnnounce;
+	  return automotive_profile_config.transmitAnnounce;
   }
 
   /**


### PR DESCRIPTION
getTransmitAnnounce() should not depend on automotive being enabled.
This prevents announce messages from being sent when not in automotive
mode.