### PR TITLE
[gPTP] Refactor automotive to simplify getters

### DIFF
--- a/daemons/gptp/common/avbts_clock.hpp
+++ b/daemons/gptp/common/avbts_clock.hpp
@@ -69,7 +69,7 @@ typedef struct {
 
 /* @brief Structure for automotive profile configuration*/
 typedef struct {
-	bool automotiveProfile; // Enable automoitve profile? This can be true when externalPortConfiguration is enabled
+	bool automotiveProfile; // Enable automotive profile? This can be true when externalPortConfiguration is enabled
 	bool transmitAnnounce; // Transmit announce messages? This is set to false by default in automotive_profile
 	bool forceAsCapable; // AsCapable always be true? This is set to true by default in automotive_profile
 	bool negotiateSyncRate; // Enable sync rate negotiation? This is set tot true by default in automotive_profile
@@ -425,7 +425,7 @@ public:
   * @brief  Gets automotive_profile attribute
   * @return automotive_profile
   */
-  bool getAutomotiveProfile(void) {
+  bool automotiveProfileEnabled(void) {
 	  return automotive_profile_config.automotiveProfile;
   }
 
@@ -433,7 +433,7 @@ public:
   * @brief  Gets transmit_announce attribute
   * @return transmit_announce attribute
   */
-  bool getTransmitAnnounce(void) {
+  bool transmitAnnounceEnabled(void) {
 	  return automotive_profile_config.transmitAnnounce;
   }
 
@@ -441,36 +441,32 @@ public:
   * @brief  Gets asCapable_true attribute
   * @return asCapable_true attribute
   */
-  bool getForceAsCapable(void) {
-	  return automotive_profile_config.automotiveProfile
-	         && automotive_profile_config.forceAsCapable;
+  bool forceAsCapable(void) {
+	  return automotive_profile_config.forceAsCapable;
   }
 
   /**
   * @brief  Gets negotiate_sync_rate attribute
   * @return negotiate_sync_rate attribute
   */
-  bool getNegotiateSyncRate(void) {
-	  return automotive_profile_config.automotiveProfile
-	         && automotive_profile_config.negotiateSyncRate;
+  bool negotiateSyncRateEnabled(void) {
+	  return automotive_profile_config.negotiateSyncRate;
   }
 
   /**
   * @brief  Gets automotive_state attribute
   * @return automotive_state attribute
   */
-  bool getAutomotiveState(void) {
-	  return automotive_profile_config.automotiveProfile
-	         && automotive_profile_config.automotiveState;
+  bool automotiveStationStatesEnabled(void) {
+	  return automotive_profile_config.automotiveState;
   }
 
   /**
   * @brief  Gets automotive_test_mode attribute
   * @return automotive_test_mode attribute
   */
-  bool getAutomotiveTestMode(void) {
-	  return automotive_profile_config.automotiveProfile
-	         && automotive_profile_config.automotiveTestMode;
+  bool automotiveTestModeEnabled(void) {
+	  return automotive_profile_config.automotiveTestMode;
   }
 
   /**

--- a/daemons/gptp/common/avbts_clock.hpp
+++ b/daemons/gptp/common/avbts_clock.hpp
@@ -441,7 +441,7 @@ public:
   * @brief  Gets asCapable_true attribute
   * @return asCapable_true attribute
   */
-  bool forceAsCapable(void) {
+  bool forceAsCapableEnabled(void) {
 	  return automotive_profile_config.forceAsCapable;
   }
 

--- a/daemons/gptp/common/ieee1588clock.cpp
+++ b/daemons/gptp/common/ieee1588clock.cpp
@@ -89,27 +89,6 @@ IEEE1588Clock::IEEE1588Clock
 
 	number_ports = 0;
 
-	if (!automotiveProfileConfig.automotiveProfile) {
-		//The following boolean options are only configurable when automotive profile is enabled
-		automotiveProfileConfig.transmitAnnounce = true;
-		automotiveProfileConfig.forceAsCapable = false;
-		automotiveProfileConfig.negotiateSyncRate = false;
-		automotiveProfileConfig.automotiveState = false;
-		automotiveProfileConfig.automotiveTestMode = false;
-	} else {
-		//external port configuration feature is enabled by default in automotive profile
-		if (extPortConfig.externalPortConfiguration == EXT_DISABLED) {
-			GPTP_LOG_ERROR("Automotive profile enabled but externalPortConfiguration is disabled by user");
-			GPTP_LOG_STATUS("Enable externalPortConfiguration and set staticPortState to PTP_SLAVE by default");
-			extPortConfig.externalPortConfiguration = EXT_ENABLED;
-			extPortConfig.staticPortState = PTP_SLAVE;
-		}
-	}
-
-	if (extPortConfig.externalPortConfiguration == EXT_DISABLED) {
-		extPortConfig.staticPortState = PTP_INITIALIZING;
-	}
-
 	this->external_port_configuration = extPortConfig;
 	this->automotive_profile_config = automotiveProfileConfig;
 

--- a/daemons/gptp/common/ieee1588clock.cpp
+++ b/daemons/gptp/common/ieee1588clock.cpp
@@ -368,7 +368,7 @@ void IEEE1588Clock::setMasterOffset
 	_master_local_freq_offset = master_local_freq_offset;
 	_local_system_freq_offset = local_system_freq_offset;
 
-	if (getAutomotiveTestMode()) {
+	if (automotiveTestModeEnabled()) {
 		GPTP_LOG_STATUS("Clock offset:%lld   Clock rate ratio:%Lf   Sync Count:%u   PDelay Count:%u",
 						master_local_offset, master_local_freq_offset, sync_count, pdelay_count);
 	}
@@ -395,7 +395,7 @@ void IEEE1588Clock::setMasterOffset
 				/* Make sure that there are no transmit operations
 				   in progress */
 				getTxLockAll();
-				if (getAutomotiveTestMode()) {
+				if (automotiveTestModeEnabled()) {
 					GPTP_LOG_STATUS("Adjust clock phase offset:%lld", -master_local_offset);
 				}
 				_timestamper->HWTimestamper_adjclockphase
@@ -423,7 +423,7 @@ void IEEE1588Clock::setMasterOffset
 		if( _ppm < LOWER_FREQ_LIMIT ) _ppm = LOWER_FREQ_LIMIT;
 		if( _ppm > UPPER_FREQ_LIMIT ) _ppm = UPPER_FREQ_LIMIT;
 		if( _timestamper ) {
-			if (getAutomotiveTestMode()) {
+			if (automotiveTestModeEnabled()) {
 				GPTP_LOG_STATUS("Adjust clock rate ppm:%f", _ppm);
 			}
 			if( !_timestamper->HWTimestamper_adjclockrate( _ppm )) {

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -583,8 +583,10 @@ void IEEE1588Port::processEvent(Event e)
 
 			// TODO:Start PDelay only if the link is up.
 			if (!clock->automotiveProfileEnabled() || !clock->forceAsCapableEnabled()) {
+				if (port_state != PTP_SLAVE && port_state != PTP_MASTER) {
 					GPTP_LOG_STATUS("Starting PDelay");
 					startPDelay();
+				}
 			}
 			else {
 				GPTP_LOG_STATUS("Starting PDelay");
@@ -779,6 +781,7 @@ void IEEE1588Port::processEvent(Event e)
 		stopPDelay();
 		haltPdelay(false);
 		startPDelay();
+
 		if (clock->automotiveProfileEnabled()) {
 			GPTP_LOG_EXCEPTION("LINKUP");
 		}

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1655,13 +1655,13 @@ void PTPMessagePathDelayRespFollowUp::processMessage(IEEE1588Port * port)
 		}
 	}
 	if( !port->setLinkDelay( link_delay ) ) {
-		if((!port->getClock()->automotiveProfileEnabled() || !port->getClock()->forceAsCapable())
+		if((!port->getClock()->automotiveProfileEnabled() || !port->getClock()->forceAsCapableEnabled())
 				&& (port->getAsCapable() || !port->getAsCapableEvaluated()) ) {
 			GPTP_LOG_STATUS("Link delay %ld beyond neighborPropDelayThresh; not AsCapable", link_delay);
 			port->setAsCapable( false );
 		}
 	} else {
-		if((!port->getClock()->automotiveProfileEnabled() || !port->getClock()->forceAsCapable())
+		if((!port->getClock()->automotiveProfileEnabled() || !port->getClock()->forceAsCapableEnabled())
 				&& !port->getAsCapable() ) {
 			GPTP_LOG_STATUS("Link delay %ld within neighborPropDelayThresh; setting AsCapable", link_delay);
 			port->setAsCapable( true );

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -157,7 +157,7 @@ PTPMessageCommon *buildPTPMessage
 		GPTP_LOG_EXCEPTION("*** Received message with unsupported transportSpecific type=%d", transportSpecific);
 		goto abort;
 	}
- 
+
 	switch (messageType) {
 	case SYNC_MESSAGE:
 
@@ -1655,13 +1655,14 @@ void PTPMessagePathDelayRespFollowUp::processMessage(IEEE1588Port * port)
 		}
 	}
 	if( !port->setLinkDelay( link_delay ) ) {
-		if (!port->getClock()->getForceAsCapable()
-			&& (port->getAsCapable() || !port->getAsCapableEvaluated()) ) {
+		if((!port->getClock()->automotiveProfileEnabled() || !port->getClock()->forceAsCapable())
+				&& (port->getAsCapable() || !port->getAsCapableEvaluated()) ) {
 			GPTP_LOG_STATUS("Link delay %ld beyond neighborPropDelayThresh; not AsCapable", link_delay);
 			port->setAsCapable( false );
 		}
 	} else {
-		if (!port->getClock()->getForceAsCapable() && !port->getAsCapable() ) {
+		if((!port->getClock()->automotiveProfileEnabled() || !port->getClock()->forceAsCapable())
+				&& !port->getAsCapable() ) {
 			GPTP_LOG_STATUS("Link delay %ld within neighborPropDelayThresh; setting AsCapable", link_delay);
 			port->setAsCapable( true );
 		}
@@ -1843,7 +1844,7 @@ void PTPMessageSignalling::processMessage(IEEE1588Port * port)
 		port->startSyncIntervalTimer(waitTime);
 	}
 
-	if (!port->getClock()->getAutomotiveProfile()) {
+	if (!port->getClock()->automotiveProfileEnabled()) {
 		if (announceInterval == PTPMessageSignalling::sigMsgInterval_Initial) {
 			// TODO: Needs implementation
 			GPTP_LOG_WARNING("Signal received to set Announce message to initial interval: Not implemented");


### PR DESCRIPTION
Currently, the getters for automotive features include a check to
ensure automotive is enabled. Make the logic more explicit and
simplify these methods by moving this check to each point of use.