### PR TITLE
[gPTP] Lowering log level of message when receiving unexpected PDelayRespFup

### DIFF
--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1509,7 +1509,7 @@ void PTPMessagePathDelayRespFollowUp::processMessage(IEEE1588Port * port)
 		GPTP_LOG_DEBUG
 			("Received PDelay Response Follow Up but cannot find "
 			 "corresponding response");
-		GPTP_LOG_ERROR("%hu, %hu, %hu, %hu", resp->getSequenceId(),
+		GPTP_LOG_DEBUG("%hu, %hu, %hu, %hu", resp->getSequenceId(),
 				sequenceId, resp_port_number, req_port_number);
 
 		goto abort;


### PR DESCRIPTION
Lowering the log level of a message that I missed in one of my previous commits
(https://github.com/ni/Open-AVB/pull/15/commits). This log message was supposed
to be paired with another one that I had lowered. It resulted in me seeing a
message with sequenceIds but no context as to what they were for.