### PR TITLE
[gPTP] Only start pDelay when link is up

### DIFF
--- a/daemons/gptp/common/ether_port.cpp
+++ b/daemons/gptp/common/ether_port.cpp
@@ -315,21 +315,20 @@ bool EtherPort::_processEvent( Event e )
 	switch (e) {
 	case POWERUP:
 	case INITIALIZE:
-		// TODO: Start PDelay only if the link is up
-		GPTP_LOG_STATUS("Starting PDelay");
-		startPDelay();
+		if( getLinkUpState() ) {
+			GPTP_LOG_STATUS("Starting PDelay");
+			startPDelay();
+		}
 
 		port_ready_condition->wait_prelock();
 
-		if( !linkWatch(watchNetLinkWrapper, (void *)this) )
-		{
+		if( !linkWatch(watchNetLinkWrapper, (void *)this) ) {
 			GPTP_LOG_ERROR("Error creating port link thread");
 			ret = false;
 			break;
 		}
 
-		if( !linkOpen(openPortWrapper, (void *)this) )
-		{
+		if( !linkOpen(openPortWrapper, (void *)this) ) {
 			GPTP_LOG_ERROR("Error creating port thread");
 			ret = false;
 			break;
@@ -341,8 +340,7 @@ bool EtherPort::_processEvent( Event e )
 			setStationState(STATION_STATE_ETHERNET_READY);
 		}
 
-		if (testModeEnabled())
-		{
+		if (testModeEnabled()) {
 			APMessageTestStatus *testStatusMsg = new APMessageTestStatus(this);
 			if (testStatusMsg) {
 				testStatusMsg->sendPort(this);
@@ -906,7 +904,7 @@ void EtherPort::syncDone() {
 		}
 	}
 
-	if( !pdelay_started ) {
+	if( !pdelay_started && getLinkUpState() ) {
 		startPDelay();
 	}
 }

--- a/daemons/gptp/linux/src/daemon_cl.cpp
+++ b/daemons/gptp/linux/src/daemon_cl.cpp
@@ -229,13 +229,13 @@ int main(int argc, char **argv)
 
 	if( sd < 0 )
 	{
-		GPTP_LOG_ERROR( "isLinkUp: Failed to open socket: %s", strerror( errno ) );
+		GPTP_LOG_ERROR( "Failed to open socket: %s", strerror( errno ) );
 		return -1;
 	}
 
 	if( ioctl( sd, SIOCGIFFLAGS, static_cast< void* >( &ifr ) ) < 0 )
 	{
-		GPTP_LOG_ERROR( "isLinkUp: ioctl(SIOCGIFFLAGS) got error: %s", strerror( errno ) );
+		GPTP_LOG_ERROR( "Failed ioctl(SIOCGIFFLAGS) got error: %s", strerror( errno ) );
 		close(sd);
 		return -1;
 	}


### PR DESCRIPTION
Stating pDelay only if the link is up. The link up state is set when
the daemon starts. This is monitored by a separate thread which updates
it based on the current state.