### PR TITLE
[gPTP] Add lock to serialize ipc update functions

### DIFF
--- a/daemons/gptp/common/avbts_clock.hpp
+++ b/daemons/gptp/common/avbts_clock.hpp
@@ -160,6 +160,7 @@ private:
     FollowUpTLV *fup_status;
 
     OSLock *timerq_lock;
+    OSLock *ipc_lock;
 
 	/**
 	 * @brief  Add a new event to the timer queue
@@ -667,6 +668,15 @@ public:
   OSLock *timerQLock() {
 	  return timerq_lock;
   }
+
+  bool getIpcLock() {
+     return ipc_lock->lock() == oslock_ok ? true : false;
+  }
+
+  bool putIpcLock() {
+     return ipc_lock->unlock() == oslock_ok ? true : false;
+  }
+
 };
 
 void tick_handler(int sig);

--- a/daemons/gptp/common/common_port.cpp
+++ b/daemons/gptp/common/common_port.cpp
@@ -796,18 +796,12 @@ void CommonPort::setAsCapable(bool ascap)
 {
 	if ( ascap != asCapable ) {
 		GPTP_LOG_STATUS
-			("AsCapable: %s", ascap == true
-			 ? "Enabled" : "Disabled");
+			("AsCapable: %s", ascap == true ? "Enabled" : "Disabled");
 	}
 	if( !ascap )
 	{
 		_peer_offset_init = false;
 	}
-	asCapable = ascap;
-
-	// Assumes that a call to setAsCapable() means that 802.1AS capability
-	// has been evaluated.
-	asCapableEvaluated = true;
 
 	// Force an IPC update so that clients get notified of the change to
 	// asCapable.
@@ -842,8 +836,15 @@ void CommonPort::setAsCapable(bool ascap)
 			( this, 0, device_time, 1.0,
 			  local_system_offset, system_time,
 			  local_system_freq_offset, getSyncCount(),
-			  pdelay_count, port_state, asCapable );
+			  pdelay_count, port_state, ascap );
 	}
+
+	// Set asCapable after the ipc returns
+	asCapable = ascap;
+
+	// Assumes that a call to setAsCapable() means that 802.1AS capability
+	// has been evaluated.
+	asCapableEvaluated = true;
 }
 
 void CommonPort::startAnnounce()


### PR DESCRIPTION
Add an ipc lock that should be acquired before calling the update functions. This removes data being overwritten between calls to the update functions.