### PR TITLE
Expose Neighbor Propagation Delay to clients

### DIFF
--- a/daemons/gptp/common/avbts_clock.hpp
+++ b/daemons/gptp/common/avbts_clock.hpp
@@ -564,7 +564,7 @@ public:
     Timestamp local_time, FrequencyRatio master_local_freq_offset,
     int64_t local_system_offset, Timestamp system_time,
     FrequencyRatio local_system_freq_offset, unsigned sync_count,
-    unsigned pdelay_count, PortState port_state, bool asCapable );
+    unsigned pdelay_count, PortState port_state, bool asCapable, uint64_t mean_path_delay );
 
   /**
    * @brief  Get the IEEE1588Clock identity value

--- a/daemons/gptp/common/avbts_osipc.hpp
+++ b/daemons/gptp/common/avbts_osipc.hpp
@@ -86,7 +86,7 @@ public:
 		uint32_t pdelay_count,
 		PortState port_state,
 		bool asCapable,
-      		uint64_t mean_path_delay ) = 0;
+		uint64_t mean_path_delay ) = 0;
 
 	/**
 	 * @brief  Updates grandmaster IPC values

--- a/daemons/gptp/common/avbts_osipc.hpp
+++ b/daemons/gptp/common/avbts_osipc.hpp
@@ -85,7 +85,8 @@ public:
 		uint32_t sync_count,
 		uint32_t pdelay_count,
 		PortState port_state,
-		bool asCapable ) = 0;
+		bool asCapable, 
+      uint64_t mean_path_delay ) = 0;
 
 	/**
 	 * @brief  Updates grandmaster IPC values

--- a/daemons/gptp/common/avbts_osipc.hpp
+++ b/daemons/gptp/common/avbts_osipc.hpp
@@ -86,7 +86,7 @@ public:
 		uint32_t pdelay_count,
 		PortState port_state,
 		bool asCapable,
-      uint64_t mean_path_delay ) = 0;
+      		uint64_t mean_path_delay ) = 0;
 
 	/**
 	 * @brief  Updates grandmaster IPC values

--- a/daemons/gptp/common/avbts_osipc.hpp
+++ b/daemons/gptp/common/avbts_osipc.hpp
@@ -85,7 +85,7 @@ public:
 		uint32_t sync_count,
 		uint32_t pdelay_count,
 		PortState port_state,
-		bool asCapable, 
+		bool asCapable,
       uint64_t mean_path_delay ) = 0;
 
 	/**

--- a/daemons/gptp/common/common_port.cpp
+++ b/daemons/gptp/common/common_port.cpp
@@ -819,7 +819,7 @@ void CommonPort::setAsCapable(bool ascap)
 		uint32_t local_clock, nominal_clock_rate;
 		FrequencyRatio local_system_freq_offset;
 		int64_t local_system_offset;
-      uint64_t mean_path_delay;
+      		uint64_t mean_path_delay;
 
       getLinkDelay
          ( &mean_path_delay );

--- a/daemons/gptp/common/common_port.cpp
+++ b/daemons/gptp/common/common_port.cpp
@@ -642,7 +642,7 @@ bool CommonPort::processEvent( Event e )
 			FrequencyRatio local_system_freq_offset;
 			int64_t local_system_offset;
          uint64_t mean_path_delay;
-         
+
          getLinkDelay
          	( &mean_path_delay );
 
@@ -741,10 +741,7 @@ bool CommonPort::processEvent( Event e )
 			FrequencyRatio local_system_freq_offset;
 			int64_t local_system_offset;
          uint64_t mean_path_delay;
-         
-         getLinkDelay
-         	( &mean_path_delay );
-         
+
          getLinkDelay
          	( &mean_path_delay );
 
@@ -823,7 +820,7 @@ void CommonPort::setAsCapable(bool ascap)
 		FrequencyRatio local_system_freq_offset;
 		int64_t local_system_offset;
       uint64_t mean_path_delay;
-         
+
       getLinkDelay
          ( &mean_path_delay );
 

--- a/daemons/gptp/common/common_port.cpp
+++ b/daemons/gptp/common/common_port.cpp
@@ -740,9 +740,9 @@ bool CommonPort::processEvent( Event e )
 			uint32_t local_clock, nominal_clock_rate;
 			FrequencyRatio local_system_freq_offset;
 			int64_t local_system_offset;
-         		uint64_t mean_path_delay;
+			uint64_t mean_path_delay;
 
-         		getLinkDelay
+			getLinkDelay
 				( &mean_path_delay );
 
 			getDeviceTime
@@ -821,8 +821,8 @@ void CommonPort::setAsCapable(bool ascap)
 		int64_t local_system_offset;
 		uint64_t mean_path_delay;
 
-      		getLinkDelay
-         		( &mean_path_delay );
+		getLinkDelay
+			( &mean_path_delay );
 
 		getDeviceTime
 			( system_time, device_time,

--- a/daemons/gptp/common/common_port.cpp
+++ b/daemons/gptp/common/common_port.cpp
@@ -641,10 +641,10 @@ bool CommonPort::processEvent( Event e )
 			uint32_t local_clock, nominal_clock_rate;
 			FrequencyRatio local_system_freq_offset;
 			int64_t local_system_offset;
-         uint64_t mean_path_delay;
+			uint64_t mean_path_delay;
 
-         getLinkDelay
-         	( &mean_path_delay );
+			getLinkDelay
+				( &mean_path_delay );
 
 			getDeviceTime
 				( system_time, device_time,

--- a/daemons/gptp/common/common_port.cpp
+++ b/daemons/gptp/common/common_port.cpp
@@ -740,10 +740,10 @@ bool CommonPort::processEvent( Event e )
 			uint32_t local_clock, nominal_clock_rate;
 			FrequencyRatio local_system_freq_offset;
 			int64_t local_system_offset;
-         uint64_t mean_path_delay;
+         		uint64_t mean_path_delay;
 
-         getLinkDelay
-         	( &mean_path_delay );
+         		getLinkDelay
+				( &mean_path_delay );
 
 			getDeviceTime
 				( system_time, device_time,
@@ -821,8 +821,8 @@ void CommonPort::setAsCapable(bool ascap)
 		int64_t local_system_offset;
       		uint64_t mean_path_delay;
 
-      getLinkDelay
-         ( &mean_path_delay );
+      		getLinkDelay
+         		( &mean_path_delay );
 
 		getDeviceTime
 			( system_time, device_time,

--- a/daemons/gptp/common/common_port.cpp
+++ b/daemons/gptp/common/common_port.cpp
@@ -641,6 +641,10 @@ bool CommonPort::processEvent( Event e )
 			uint32_t local_clock, nominal_clock_rate;
 			FrequencyRatio local_system_freq_offset;
 			int64_t local_system_offset;
+         uint64_t mean_path_delay;
+         
+         getLinkDelay
+         	( &mean_path_delay );
 
 			getDeviceTime
 				( system_time, device_time,
@@ -666,7 +670,7 @@ bool CommonPort::processEvent( Event e )
 				( this, 0, device_time, 1.0,
 				  local_system_offset, system_time,
 				  local_system_freq_offset, getSyncCount(),
-				  pdelay_count, port_state, asCapable );
+				  pdelay_count, port_state, asCapable, mean_path_delay );
 		}
 
 		break;
@@ -736,6 +740,13 @@ bool CommonPort::processEvent( Event e )
 			uint32_t local_clock, nominal_clock_rate;
 			FrequencyRatio local_system_freq_offset;
 			int64_t local_system_offset;
+         uint64_t mean_path_delay;
+         
+         getLinkDelay
+         	( &mean_path_delay );
+         
+         getLinkDelay
+         	( &mean_path_delay );
 
 			getDeviceTime
 				( system_time, device_time,
@@ -759,7 +770,7 @@ bool CommonPort::processEvent( Event e )
 				( this, 0, device_time, 1.0,
 				  local_system_offset, system_time,
 				  local_system_freq_offset, getSyncCount(),
-				  pdelay_count, port_state, asCapable );
+				  pdelay_count, port_state, asCapable, mean_path_delay );
 		}
 
 		// Call media specific action for completed sync
@@ -811,6 +822,10 @@ void CommonPort::setAsCapable(bool ascap)
 		uint32_t local_clock, nominal_clock_rate;
 		FrequencyRatio local_system_freq_offset;
 		int64_t local_system_offset;
+      uint64_t mean_path_delay;
+         
+      getLinkDelay
+         ( &mean_path_delay );
 
 		getDeviceTime
 			( system_time, device_time,
@@ -836,7 +851,7 @@ void CommonPort::setAsCapable(bool ascap)
 			( this, 0, device_time, 1.0,
 			  local_system_offset, system_time,
 			  local_system_freq_offset, getSyncCount(),
-			  pdelay_count, port_state, ascap );
+			  pdelay_count, port_state, ascap, mean_path_delay );
 	}
 
 	// Set asCapable after the ipc returns

--- a/daemons/gptp/common/common_port.cpp
+++ b/daemons/gptp/common/common_port.cpp
@@ -819,7 +819,7 @@ void CommonPort::setAsCapable(bool ascap)
 		uint32_t local_clock, nominal_clock_rate;
 		FrequencyRatio local_system_freq_offset;
 		int64_t local_system_offset;
-      		uint64_t mean_path_delay;
+		uint64_t mean_path_delay;
 
       		getLinkDelay
          		( &mean_path_delay );

--- a/daemons/gptp/common/gptp_log.cpp
+++ b/daemons/gptp/common/gptp_log.cpp
@@ -117,7 +117,7 @@ void gptpLog(GPTP_LOG_LEVEL level, const char *tag, const char *path, int line, 
 			   tag, tmNow.tm_hour, tmNow.tm_min, tmNow.tm_sec, millis, msg);
 	}
 #else
-	DltLogLevelType dlt_level; 
+	DltLogLevelType dlt_level;
 
 	switch (level) {
 	case GPTP_LOG_LVL_CRITICAL:

--- a/daemons/gptp/common/ieee1588clock.cpp
+++ b/daemons/gptp/common/ieee1588clock.cpp
@@ -351,7 +351,8 @@ void IEEE1588Clock::setMasterOffset
   Timestamp local_time, FrequencyRatio master_local_freq_offset,
   int64_t local_system_offset, Timestamp system_time,
   FrequencyRatio local_system_freq_offset, unsigned sync_count,
-  unsigned pdelay_count, PortState port_state, bool asCapable )
+  unsigned pdelay_count, PortState port_state, bool asCapable,
+  uint64_t mean_path_delay )
 {
 	_master_local_freq_offset = master_local_freq_offset;
 	_local_system_freq_offset = local_system_freq_offset;
@@ -376,7 +377,7 @@ void IEEE1588Clock::setMasterOffset
 		ipc->update(
 			master_local_offset, local_system_offset, master_local_freq_offset,
 			local_system_freq_offset, TIMESTAMP_TO_NS(local_time),
-			sync_count, pdelay_count, port_state, asCapable);
+			sync_count, pdelay_count, port_state, asCapable, mean_path_delay);
 
 		ipc->update_grandmaster(
 			grandmaster_id, domain_number);

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1142,7 +1142,7 @@ void PTPMessageFollowUp::processMessage( EtherPort *port )
 			  local_system_offset, system_time, local_system_freq_offset,
 			  port->getSyncCount(), port->getPdelayCount(),
 			  port->getPortState(), port->getAsCapable(),
-           port->getLinkDelay() );
+           		  port->getLinkDelay() );
 		port->syncDone();
 		// Restart the SYNC_RECEIPT timer
 		port->startSyncReceiptTimer((unsigned long long)

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1141,7 +1141,8 @@ void PTPMessageFollowUp::processMessage( EtherPort *port )
 			( port, scalar_offset, sync_arrival, local_clock_adjustment,
 			  local_system_offset, system_time, local_system_freq_offset,
 			  port->getSyncCount(), port->getPdelayCount(),
-			  port->getPortState(), port->getAsCapable() );
+			  port->getPortState(), port->getAsCapable(), 
+           port->getLinkDelay() );
 		port->syncDone();
 		// Restart the SYNC_RECEIPT timer
 		port->startSyncReceiptTimer((unsigned long long)

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1141,7 +1141,7 @@ void PTPMessageFollowUp::processMessage( EtherPort *port )
 			( port, scalar_offset, sync_arrival, local_clock_adjustment,
 			  local_system_offset, system_time, local_system_freq_offset,
 			  port->getSyncCount(), port->getPdelayCount(),
-			  port->getPortState(), port->getAsCapable(), 
+			  port->getPortState(), port->getAsCapable(),
            port->getLinkDelay() );
 		port->syncDone();
 		// Restart the SYNC_RECEIPT timer

--- a/daemons/gptp/linux/src/linux_hal_common.cpp
+++ b/daemons/gptp/linux/src/linux_hal_common.cpp
@@ -947,7 +947,7 @@ bool LinuxSharedMemoryIPC::update(
 	uint32_t sync_count,
 	uint32_t pdelay_count,
 	PortState port_state,
-	bool asCapable, 
+	bool asCapable,
 	uint64_t mean_path_delay )
 {
 	int buf_offset = 0;

--- a/daemons/gptp/linux/src/linux_hal_common.cpp
+++ b/daemons/gptp/linux/src/linux_hal_common.cpp
@@ -947,7 +947,8 @@ bool LinuxSharedMemoryIPC::update(
 	uint32_t sync_count,
 	uint32_t pdelay_count,
 	PortState port_state,
-	bool asCapable )
+	bool asCapable, 
+	uint64_t mean_path_delay )
 {
 	int buf_offset = 0;
 	pid_t process_id = getpid();

--- a/daemons/gptp/linux/src/linux_hal_common.hpp
+++ b/daemons/gptp/linux/src/linux_hal_common.hpp
@@ -668,7 +668,8 @@ public:
 		uint32_t sync_count,
 		uint32_t pdelay_count,
 		PortState port_state,
-		bool asCapable );
+		bool asCapable,
+		uint64_t mean_path_delay );
 
 	/**
 	 * @brief Updates grandmaster IPC values

--- a/daemons/gptp/linux/src/linux_hal_generic_adj.cpp
+++ b/daemons/gptp/linux/src/linux_hal_generic_adj.cpp
@@ -1,31 +1,31 @@
 /******************************************************************************
 
-  Copyright (c) 2009-2012, Intel Corporation 
+  Copyright (c) 2009-2012, Intel Corporation
   All rights reserved.
-  
-  Redistribution and use in source and binary forms, with or without 
+
+  Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
-  
-   1. Redistributions of source code must retain the above copyright notice, 
+
+   1. Redistributions of source code must retain the above copyright notice,
       this list of conditions and the following disclaimer.
-  
-   2. Redistributions in binary form must reproduce the above copyright 
-      notice, this list of conditions and the following disclaimer in the 
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-  
-   3. Neither the name of the Intel Corporation nor the names of its 
-      contributors may be used to endorse or promote products derived from 
+
+   3. Neither the name of the Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived from
       this software without specific prior written permission.
-  
+
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
-  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
 
@@ -53,7 +53,7 @@ bool LinuxTimestamperGeneric::HWTimestamper_adjclockphase( int64_t phase_adjust 
 	bool ret = true;
 	LinuxTimerFactory factory;
 	OSTimer *timer = factory.createTimer();
-		
+
 	/* Walk list of interfaces disabling them all */
 	iface_iter = iface_list.begin();
 	for
@@ -61,15 +61,15 @@ bool LinuxTimestamperGeneric::HWTimestamper_adjclockphase( int64_t phase_adjust 
 		  ++iface_iter ) {
 		(*iface_iter)->disable_rx_queue();
 	}
-		
+
 	rxTimestampList.clear();
-		
+
 	/* Wait 180 ms - This is plenty of time for any time sync frames
 	   to clear the queue */
 	timer->sleep(180000);
-		
+
 	++version;
-		
+
 	tx.modes = ADJ_SETOFFSET | ADJ_NANO;
 	if( phase_adjust >= 0 ) {
 		tx.time.tv_sec  = phase_adjust / 1000000000LL;
@@ -82,18 +82,18 @@ bool LinuxTimestamperGeneric::HWTimestamper_adjclockphase( int64_t phase_adjust 
 	if( !Adjust( &tx )) {
 		ret = false;
 	}
-		
+
 	// Walk list of interfaces re-enabling them
 	iface_iter = iface_list.begin();
 	for( iface_iter = iface_list.begin(); iface_iter != iface_list.end();
 		 ++iface_iter ) {
 		(*iface_iter)->clear_reenable_rx_queue();
 	}
-	  
+
 	delete timer;
 	return ret;
 }
-	
+
 bool LinuxTimestamperGeneric::HWTimestamper_adjclockrate( float freq_offset ) const {
 	struct timex tx;
 	tx.modes = ADJ_FREQUENCY;


### PR DESCRIPTION
Modified gPTP to expose the Neighbor Propagation Delay to the clients. Used the native function getLinkDelay to grab the neighbor propagation delay (one way delay) whenever the network interface information is updated. Verified that we're seeing reasonable values that update as we expect them to. This feature would be helpful for people designing topologies where neighbor propagation delay may exceed our set threshold, or for optimizing their choice of cabling for their ethernet physical layer.